### PR TITLE
Ladder overlay, guard lure status and bugfixes.

### DIFF
--- a/src/main/java/io/cbitler/stealingartefacts/Constants.java
+++ b/src/main/java/io/cbitler/stealingartefacts/Constants.java
@@ -4,4 +4,8 @@ public class Constants {
     final static int PATROL_ID_MIN = 6973;
     final static int PATROL_ID_MAX = 6980;
     final static int STEALING_ARTEFACTS_VARBIT = 4903;
+
+    final static int SOUTH = 0;
+
+    final static int WEST = 512;
 }

--- a/src/main/java/io/cbitler/stealingartefacts/Constants.java
+++ b/src/main/java/io/cbitler/stealingartefacts/Constants.java
@@ -4,8 +4,6 @@ public class Constants {
     final static int PATROL_ID_MIN = 6973;
     final static int PATROL_ID_MAX = 6980;
     final static int STEALING_ARTEFACTS_VARBIT = 4903;
-
     final static int SOUTH = 0;
-
     final static int WEST = 512;
 }

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
@@ -13,6 +13,8 @@ public interface StealingArtefactsConfig extends Config {
 
     String HIGHLIGHT_LADDERS = "highlightLadders";
 
+    String HIGHLIGHT_GUARD_LURES = "highlightGuardLures";
+
     String SHOW_TO_NEXT_LEVEL = "showToNextLevel";
 
     @ConfigItem(
@@ -38,6 +40,13 @@ public interface StealingArtefactsConfig extends Config {
             description = "Whether or not to highlight house ladders"
     )
     default boolean highlightLadders() { return true; }
+
+    @ConfigItem(
+            keyName = HIGHLIGHT_GUARD_LURES,
+            name = "Highlight Lured Guards",
+            description = "Whether or not to highlight guards when lured/positioned correctly"
+    )
+    default boolean highlightGuardLures() { return true; }
 
     @ConfigItem(
             keyName = SHOW_TO_NEXT_LEVEL,

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
@@ -11,6 +11,8 @@ public interface StealingArtefactsConfig extends Config {
 
     String HIGHLIGHT_PATROLS = "highlightPatrols";
 
+    String HIGHLIGHT_LADDERS = "highlightLadders";
+
     String SHOW_TO_NEXT_LEVEL = "showToNextLevel";
 
     @ConfigItem(
@@ -29,6 +31,13 @@ public interface StealingArtefactsConfig extends Config {
             description = "Whether or not to highlight patrols"
     )
     default boolean highlightPatrols() { return true; }
+
+    @ConfigItem(
+            keyName = HIGHLIGHT_LADDERS,
+            name = "Highlight House Ladders",
+            description = "Whether or not to highlight house ladders"
+    )
+    default boolean highlightLadders() { return true; }
 
     @ConfigItem(
             keyName = SHOW_TO_NEXT_LEVEL,

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsHouseOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsHouseOverlay.java
@@ -36,7 +36,7 @@ public class StealingArtefactsHouseOverlay extends Overlay {
     }
 
     /**
-     * Draw an overlay on the drawers for the minigame where applicable
+     * Draw an overlay on the drawers and ladders for the minigame where applicable
      * @param graphics The graphics to draw the overlay with
      * @return null, use OverlayUtil to render hoverable area
      */

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsHouseOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsHouseOverlay.java
@@ -3,6 +3,7 @@ package io.cbitler.stealingartefacts;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.Point;
+import net.runelite.api.ObjectID;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -22,13 +23,16 @@ public class StealingArtefactsHouseOverlay extends Overlay {
     private final Client client;
     private final StealingArtefactsPlugin plugin;
 
+    private final StealingArtefactsConfig config;
+
     @Inject
-    StealingArtefactsHouseOverlay(Client client, StealingArtefactsPlugin plugin) {
+    StealingArtefactsHouseOverlay(Client client, StealingArtefactsPlugin plugin, StealingArtefactsConfig config) {
         super(plugin);
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
         this.client = client;
         this.plugin = plugin;
+        this.config = config;
     }
 
     /**
@@ -43,9 +47,14 @@ public class StealingArtefactsHouseOverlay extends Overlay {
         }
 
         Point mousePosition = client.getMouseCanvasPosition();
-        if (client.getPlane() == plugin.currentState.getDrawerPlane() && plugin.markedObject != null) {
-            OverlayUtil.renderHoverableArea(graphics, plugin.markedObject.getClickbox(), mousePosition,
-                    CLICKBOX_FILL_COLOR, CLICKBOX_BORDER, CLICKBOX_HOVER_BORDER);
+        for (GameObject object : plugin.markedObjects) {
+            if (object.getId() == ObjectID.LADDER_27634 && !(config.highlightLadders())) {
+                continue;
+            }
+            if (client.getPlane() == object.getWorldLocation().getPlane()) {
+                OverlayUtil.renderHoverableArea(graphics, object.getClickbox(), mousePosition, CLICKBOX_FILL_COLOR,
+                        CLICKBOX_BORDER, CLICKBOX_HOVER_BORDER);
+            }
         }
 
         return null;

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsOverlay.java
@@ -2,6 +2,7 @@ package io.cbitler.stealingartefacts;
 
 import net.runelite.api.Client;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -53,6 +54,25 @@ public class StealingArtefactsOverlay extends Overlay {
                 panelComponent.getChildren().add(LineComponent.builder().left("Artefacts until goal:").build());
                 panelComponent.getChildren().add(LineComponent.builder().left(String.valueOf(plugin.artefactsToGoal)).build());
             }
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+            panelComponent.getChildren().add(LineComponent.builder().left("Guard Lures:").build());
+
+            String eastGuardLured = plugin.eastGuardLured ? "\u2713" : "\u2717";
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Eastern Guard")
+                    .right(eastGuardLured)
+                    .rightFont(FontManager.getDefaultFont())
+                    .rightColor(plugin.eastGuardLured ? Color.GREEN : Color.RED)
+                    .build());
+
+            String southEastGuardLured = plugin.southEastGuardLured ? "\u2713" : "\u2717";
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("South-East Guard")
+                    .right(southEastGuardLured)
+                    .rightFont(FontManager.getDefaultFont())
+                    .rightColor(plugin.southEastGuardLured ? Color.GREEN : Color.RED)
+                    .build());
 
             panelComponent.setPreferredSize(new Dimension(200, 0));
             return panelComponent.render(graphics);

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsOverlay.java
@@ -55,24 +55,26 @@ public class StealingArtefactsOverlay extends Overlay {
                 panelComponent.getChildren().add(LineComponent.builder().left(String.valueOf(plugin.artefactsToGoal)).build());
             }
 
-            panelComponent.getChildren().add(LineComponent.builder().build());
-            panelComponent.getChildren().add(LineComponent.builder().left("Guard Lures:").build());
+            if (config.highlightGuardLures()) {
+                panelComponent.getChildren().add(LineComponent.builder().build());
+                panelComponent.getChildren().add(LineComponent.builder().left("Guard Lures:").build());
 
-            String eastGuardLured = plugin.eastGuardLured ? "\u2713" : "\u2717";
-            panelComponent.getChildren().add(LineComponent.builder()
-                    .left("Eastern Guard")
-                    .right(eastGuardLured)
-                    .rightFont(FontManager.getDefaultFont())
-                    .rightColor(plugin.eastGuardLured ? Color.GREEN : Color.RED)
-                    .build());
+                String eastGuardLured = plugin.eastGuardLured ? "\u2713" : "\u2717";
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Eastern Guard")
+                        .right(eastGuardLured)
+                        .rightFont(FontManager.getDefaultFont())
+                        .rightColor(plugin.eastGuardLured ? Color.GREEN : Color.RED)
+                        .build());
 
-            String southEastGuardLured = plugin.southEastGuardLured ? "\u2713" : "\u2717";
-            panelComponent.getChildren().add(LineComponent.builder()
-                    .left("South-East Guard")
-                    .right(southEastGuardLured)
-                    .rightFont(FontManager.getDefaultFont())
-                    .rightColor(plugin.southEastGuardLured ? Color.GREEN : Color.RED)
-                    .build());
+                String southEastGuardLured = plugin.southEastGuardLured ? "\u2713" : "\u2717";
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("South-East Guard")
+                        .right(southEastGuardLured)
+                        .rightFont(FontManager.getDefaultFont())
+                        .rightColor(plugin.southEastGuardLured ? Color.GREEN : Color.RED)
+                        .build());
+            }
 
             panelComponent.setPreferredSize(new Dimension(200, 0));
             return panelComponent.render(graphics);

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPatrolOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPatrolOverlay.java
@@ -20,6 +20,8 @@ public class StealingArtefactsPatrolOverlay extends Overlay {
     public static final Color CLICKBOX_BORDER = Color.YELLOW;
     public static final Color CLICKBOX_FILL_COLOR = new Color(255, 0, 0, 50);
 
+    public static final Color CLICKBOX_FILL_COLOR_LURED = new Color(0, 255, 0, 50);
+
     private final StealingArtefactsPlugin plugin;
     private final StealingArtefactsConfig config;
     private final Client client;
@@ -43,8 +45,13 @@ public class StealingArtefactsPatrolOverlay extends Overlay {
         Point mousePosition = client.getMouseCanvasPosition();
         if (config.highlightPatrols()) {
             for (NPC actor : plugin.markedNPCs) {
-                OverlayUtil.renderHoverableArea(graphics, actor.getConvexHull(),
-                        mousePosition, CLICKBOX_FILL_COLOR, CLICKBOX_BORDER, CLICKBOX_BORDER);
+                if ((actor.getId() == Constants.PATROL_ID_MAX) && plugin.isGuardLured(actor)) {
+                    OverlayUtil.renderHoverableArea(graphics, actor.getConvexHull(),
+                            mousePosition, CLICKBOX_FILL_COLOR_LURED, CLICKBOX_BORDER, CLICKBOX_BORDER);
+                } else {
+                    OverlayUtil.renderHoverableArea(graphics, actor.getConvexHull(),
+                            mousePosition, CLICKBOX_FILL_COLOR, CLICKBOX_BORDER, CLICKBOX_BORDER);
+                }
             }
         }
 

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPatrolOverlay.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPatrolOverlay.java
@@ -45,7 +45,7 @@ public class StealingArtefactsPatrolOverlay extends Overlay {
         Point mousePosition = client.getMouseCanvasPosition();
         if (config.highlightPatrols()) {
             for (NPC actor : plugin.markedNPCs) {
-                if ((actor.getId() == Constants.PATROL_ID_MAX) && plugin.isGuardLured(actor)) {
+                if ((actor.getId() == Constants.PATROL_ID_MAX) && plugin.isGuardLured(actor) && config.highlightGuardLures()) {
                     OverlayUtil.renderHoverableArea(graphics, actor.getConvexHull(),
                             mousePosition, CLICKBOX_FILL_COLOR_LURED, CLICKBOX_BORDER, CLICKBOX_BORDER);
                 } else {

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -115,6 +115,10 @@ public class StealingArtefactsPlugin extends Plugin {
             markedNPCs.clear();
             markedObjects.clear();
         }
+        if (e.getGameState() == GameState.LOGGED_IN && !(isInPisc(client.getLocalPlayer().getWorldLocation()))) {
+            markedNPCs.clear();
+            markedObjects.clear();
+        }
     }
     @Subscribe
     public void onConfigChanged(ConfigChanged c) {

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -60,6 +60,12 @@ public class StealingArtefactsPlugin extends Plugin {
 
     public boolean showArtefactsToNextLevel = true;
 
+    public static final WorldPoint EAST_GUARD_POS = new WorldPoint(1777, 3746,0);
+    public static final WorldPoint SOUTHEAST_GUARD_POS = new WorldPoint(1780, 3731,0);
+    public boolean eastGuardLured = false;
+
+    public boolean southEastGuardLured = false;
+
     public NPC captainKhaled;
 
     public int artefactsToGoal = -1;
@@ -326,5 +332,24 @@ public class StealingArtefactsPlugin extends Plugin {
         }
 
         return false;
+    }
+
+    public boolean isGuardLured(NPC guard) {
+        boolean isLured = false;
+        if (guard.getWorldLocation().distanceTo(EAST_GUARD_POS) == 0 && guard.getCurrentOrientation() == Constants.SOUTH) {
+            isLured = true;
+            eastGuardLured = true;
+        } else if (guard.getWorldLocation().distanceTo(EAST_GUARD_POS) == 0) {
+            eastGuardLured = false;
+        }
+
+        if (guard.getWorldLocation().distanceTo(SOUTHEAST_GUARD_POS) == 0 && guard.getCurrentOrientation() == Constants.WEST) {
+            isLured = true;
+            southEastGuardLured = true;
+        } else if (guard.getWorldLocation().distanceTo(SOUTHEAST_GUARD_POS) == 0) {
+            southEastGuardLured = false;
+        }
+
+        return isLured;
     }
 }

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -297,14 +297,14 @@ public class StealingArtefactsPlugin extends Plugin {
      * @return True if we should mark it, false if we shouldn't.
      */
     public boolean shouldMarkObject(GameObject object) {
-        boolean isDrawer = false;
+        boolean shouldMark = false;
         if (currentState != null && currentState.getDrawerId() != -1) {
-            isDrawer = object.getId() == currentState.getDrawerId();
+            shouldMark  = object.getId() == currentState.getDrawerId();
         }
         if (currentState != null && currentState.getLadderId() != -1 && (object.getWorldLocation().distanceTo(currentState.getLadderLocation()) == 0)) {
-            isDrawer = object.getId() == currentState.getLadderId();
+            shouldMark  = object.getId() == currentState.getLadderId();
         }
-        return isDrawer;
+        return shouldMark;
     }
 
     /**
@@ -347,17 +347,20 @@ public class StealingArtefactsPlugin extends Plugin {
      */
     public boolean isGuardLured(NPC guard) {
         boolean isLured = false;
-        if (guard.getWorldLocation().distanceTo(EAST_GUARD_POS) == 0 && guard.getCurrentOrientation() == Constants.SOUTH) {
+        int eastGuardDistance = guard.getWorldLocation().distanceTo(EAST_GUARD_POS);
+        int southEastGuardDistance = guard.getWorldLocation().distanceTo(SOUTHEAST_GUARD_POS);
+
+        if (eastGuardDistance == 0 && guard.getCurrentOrientation() == Constants.SOUTH) {
             isLured = true;
             eastGuardLured = true;
-        } else if (guard.getWorldLocation().distanceTo(EAST_GUARD_POS) == 0) {
+        } else if (eastGuardDistance == 0) {
             eastGuardLured = false;
         }
 
-        if (guard.getWorldLocation().distanceTo(SOUTHEAST_GUARD_POS) == 0 && guard.getCurrentOrientation() == Constants.WEST) {
+        if (southEastGuardDistance == 0 && guard.getCurrentOrientation() == Constants.WEST) {
             isLured = true;
             southEastGuardLured = true;
-        } else if (guard.getWorldLocation().distanceTo(SOUTHEAST_GUARD_POS) == 0) {
+        } else if (southEastGuardDistance == 0) {
             southEastGuardLured = false;
         }
 

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -156,8 +156,10 @@ public class StealingArtefactsPlugin extends Plugin {
                 }
             }
         } else {
-            if (isInPisc(client.getHintArrowPoint())) {
-                client.clearHintArrow();
+            if (client.getHintArrowPoint() != null) {
+                if (isInPisc(client.getHintArrowPoint())) {
+                    client.clearHintArrow();
+                }
             }
         }
     }

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -50,7 +50,7 @@ public class StealingArtefactsPlugin extends Plugin {
     @Inject
     private XpTrackerService xpTrackerService;
 
-    public GameObject markedObject;
+    public HashSet<GameObject> markedObjects = new HashSet<>();
 
     public HashSet<NPC> markedNPCs = new HashSet<>();
 
@@ -107,7 +107,7 @@ public class StealingArtefactsPlugin extends Plugin {
     public void onGameStateChanged(GameStateChanged e) {
         if (e.getGameState() == GameState.LOGGING_IN || e.getGameState() == GameState.LOGIN_SCREEN || e.getGameState() == GameState.HOPPING) {
             markedNPCs.clear();
-            markedObject = null;
+            markedObjects.clear();
         }
     }
     @Subscribe
@@ -163,7 +163,7 @@ public class StealingArtefactsPlugin extends Plugin {
     @Subscribe
     public void onGameObjectSpawned(GameObjectSpawned event) {
         if (shouldMarkObject(event.getGameObject())) {
-            markedObject = event.getGameObject();
+            markedObjects.add(event.getGameObject());
         }
     }
 
@@ -173,8 +173,8 @@ public class StealingArtefactsPlugin extends Plugin {
      */
     @Subscribe
     public void onGameObjectDespawned(GameObjectDespawned event) {
-        if (event.getGameObject() != null && markedObject != null && event.getGameObject().getId() == markedObject.getId()) {
-            markedObject = null;
+        if (event.getGameObject() != null && !markedObjects.isEmpty()) {
+            markedObjects.remove(event.getGameObject());
         }
     }
 
@@ -289,7 +289,9 @@ public class StealingArtefactsPlugin extends Plugin {
         if (currentState != null && currentState.getDrawerId() != -1) {
             isDrawer = object.getId() == currentState.getDrawerId();
         }
-
+        if (currentState != null && currentState.getLadderId() != -1 && (object.getWorldLocation().distanceTo(currentState.getLadderLocation()) == 0)) {
+            isDrawer = object.getId() == currentState.getLadderId();
+        }
         return isDrawer;
     }
 

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsPlugin.java
@@ -286,7 +286,7 @@ public class StealingArtefactsPlugin extends Plugin {
     }
 
     /**
-     * Check if we should be marking this object - mainly if it is the target drawer
+     * Check if we should be marking this object - for both drawers and ladders
      * @param object The game object to check
      * @return True if we should mark it, false if we shouldn't.
      */
@@ -334,6 +334,11 @@ public class StealingArtefactsPlugin extends Plugin {
         return false;
     }
 
+    /**
+     * Check if the applicable guards is facing the lured direction
+     * @param guard The NPC object to check
+     * @return True if guard is facing correct position, otherwise false
+     */
     public boolean isGuardLured(NPC guard) {
         boolean isLured = false;
         if (guard.getWorldLocation().distanceTo(EAST_GUARD_POS) == 0 && guard.getCurrentOrientation() == Constants.SOUTH) {

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsState.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsState.java
@@ -10,20 +10,22 @@ import net.runelite.api.coords.WorldPoint;
 @Getter
 public enum StealingArtefactsState {
     NO_TASK(""),
-    NORTHERN("Northern house", ObjectID.DRAWERS_27771, 0, new WorldPoint(1768, 3750, 0)),
-    SOUTHEASTERN("South-Eastern house", ObjectID.DRAWERS_27772, 1, new WorldPoint(1775, 3733, 1)),
-    SOUTHERN("Southern house", ObjectID.DRAWERS_27773, 1, new WorldPoint(1765, 3732, 1)),
-    SOUTHWESTERN("South-Western house", ObjectID.DRAWERS_27774, 1, new WorldPoint(1749, 3734, 1)),
-    WESTERN("Western house", ObjectID.DRAWERS_27775, 1, new WorldPoint(1750, 3749, 1)),
-    NORTHWESTERN("North-Western house", ObjectID.DRAWERS_27776, 1, new WorldPoint(1750, 3761, 1)),
+    NORTHERN("Northern house", ObjectID.DRAWERS_27771, ObjectID.LADDER_27634, 0, new WorldPoint(1768, 3750, 0), new WorldPoint(0, 0, 0)),
+    SOUTHEASTERN("South-Eastern house", ObjectID.DRAWERS_27772, ObjectID.LADDER_27634, 1, new WorldPoint(1775, 3733, 1), new WorldPoint(1776, 3730, 0)),
+    SOUTHERN("Southern house", ObjectID.DRAWERS_27773, ObjectID.LADDER_27634, 1, new WorldPoint(1765, 3732, 1), new WorldPoint(1768, 3733, 0)),
+    SOUTHWESTERN("South-Western house", ObjectID.DRAWERS_27774, ObjectID.LADDER_27634, 1, new WorldPoint(1749, 3734, 1), new WorldPoint(1749, 3730, 0)),
+    WESTERN("Western house", ObjectID.DRAWERS_27775, ObjectID.LADDER_27634, 1, new WorldPoint(1750, 3749, 1), new WorldPoint(1751, 3751, 0)),
+    NORTHWESTERN("North-Western house", ObjectID.DRAWERS_27776, ObjectID.LADDER_27634, 1, new WorldPoint(1750, 3761, 1), new WorldPoint(1750, 3756, 0)),
     FAILURE("Artefact Failed - Return to Captain Khaled"),
     DELIVER_ARTEFACT("Deliver the Artefact to Captain Khaled");
 
 
     private final String target;
     private final int drawerId;
+    private final int ladderId;
     private final int drawerPlane;
     private final WorldPoint hintLocation;
+    private final WorldPoint ladderLocation;
 
     /**
      * Create a state pointing at a specific house
@@ -32,11 +34,13 @@ public enum StealingArtefactsState {
      * @param drawerPlane The game object ID of the
      * @param hintLocation The hint location for the house
      */
-    StealingArtefactsState(String target, int drawerId, int drawerPlane, WorldPoint hintLocation) {
+    StealingArtefactsState(String target, int drawerId, int ladderId, int drawerPlane, WorldPoint hintLocation, WorldPoint ladderLocation) {
         this.target = target;
         this.drawerId = drawerId;
+        this.ladderId = ladderId;
         this.drawerPlane = drawerPlane;
         this.hintLocation = hintLocation;
+        this.ladderLocation = ladderLocation;
     }
 
     /**
@@ -46,7 +50,9 @@ public enum StealingArtefactsState {
     StealingArtefactsState(String target) {
         this.target = target;
         drawerId = -1;
+        ladderId = -1;
         drawerPlane = -1;
         hintLocation = null;
+        ladderLocation = null;
     }
 }

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsState.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsState.java
@@ -31,8 +31,10 @@ public enum StealingArtefactsState {
      * Create a state pointing at a specific house
      * @param target The string to show in the overlay as the target
      * @param drawerId The game object ID of the drawer
-     * @param drawerPlane The game object ID of the
+     * @param ladderId The game object ID of the ladder
+     * @param drawerPlane The plane level (z) of the drawer
      * @param hintLocation The hint location for the house
+     * @param ladderLocation The plane level (z) of the ladder
      */
     StealingArtefactsState(String target, int drawerId, int ladderId, int drawerPlane, WorldPoint hintLocation, WorldPoint ladderLocation) {
         this.target = target;


### PR DESCRIPTION
I've been using this plugin a lot recently and have worked in a couple features and fixes which I've found useful.
Would greatly appreciate additional testing and review. Thanks.

### Ladder overlay 
Similar to the drawer overlay. Intended to assist with learning and efficiency. Can be toggled in settings.

<img width="500" alt="osrs_1" src="https://user-images.githubusercontent.com/26154909/182062483-18fde720-54ff-40fb-9471-6728e810ff66.png">

### Guard lure status
The east and south-east guards can be lured into facing certain directions to allow for faster, more efficient runs. When these guards are facing the optimal directions they are highlighted and their status is noted in the UI overlay.
This is intended to assist players when finding a world which is already set up, or when luring the guards themselves.
As requested in  #6.

<img width="500" alt="osrs_2" src="https://user-images.githubusercontent.com/26154909/182063442-fc6b09ff-1d16-4e95-8341-d447f9673f37.png">

### Bug fixes

- Fixed object overlays persisting after teleporting long distances. Marked objects are now cleared on the appropriate game state changes.
- Fixed NPE related to clearing the hint arrow when leaving Port Piscarilius.


